### PR TITLE
Add OvenMediaEngine docker-compose setup for LAN streaming test

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Objective:
 
 Start with a minimal, reliable pipeline on a local LAN: OBS → OvenMediaEngine (OME) via RTMP → VLC via HLS/LL-HLS. This proves base functionality (one machine publishes; another on Wi-Fi plays). Ultra-low-latency WebRTC and sync features come later.
 
+
+## Local Test
+- Start the stack: `docker compose up -d`
+- In OBS: set **Server** to `rtmp://<HOST_IP>:1935/app` and **Stream Key** to `stream`
+- In VLC (another device on the same Wi-Fi): use *Open Network Stream* with either `http://<HOST_IP>:3333/app/stream/llhls.m3u8` or `http://<HOST_IP>:3333/app/stream/master.m3u8?format=ts`
+- Note: If LL-HLS fails in VLC, try the HLS-TS URL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  ovenmediaengine:
+    image: airensoft/ovenmediaengine:latest
+    restart: unless-stopped
+    ports:
+      - "1935:1935/tcp"
+      - "3333:3333/tcp"
+      - "3334:3334/tcp"
+      - "9999:9999/udp"
+      - "3478:3478/tcp"
+      - "10000-10009:10000-10009/udp"
+    volumes:
+      - ./ome/conf:/opt/ovenmediaengine/bin/origin_conf

--- a/ome/conf/Server.xml
+++ b/ome/conf/Server.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Server version="8">
+    <Name>OvenMediaEngine</Name>
+    <Type>origin</Type>
+    <IP>*</IP>
+    <PrivacyProtection>false</PrivacyProtection>
+    <StunServer>stun.ovenmediaengine.com:13478</StunServer>
+
+    <Modules>
+        <HTTP2>
+            <Enable>true</Enable>
+        </HTTP2>
+        <LLHLS>
+            <Enable>true</Enable>
+        </LLHLS>
+    </Modules>
+
+    <Bind>
+        <Providers>
+            <RTMP>
+                <Port>1935</Port>
+                <WorkerCount>1</WorkerCount>
+            </RTMP>
+            <SRT>
+                <Port>9999</Port>
+                <WorkerCount>1</WorkerCount>
+            </SRT>
+            <WebRTC>
+                <Signalling>
+                    <Port>3333</Port>
+                    <TLSPort>3334</TLSPort>
+                    <WorkerCount>1</WorkerCount>
+                </Signalling>
+                <IceCandidates>
+                    <IceCandidate>*:10000-10009/udp</IceCandidate>
+                    <TcpRelay>*:3478</TcpRelay>
+                    <TcpForce>true</TcpForce>
+                    <TcpRelayWorkerCount>1</TcpRelayWorkerCount>
+                </IceCandidates>
+            </WebRTC>
+        </Providers>
+        <Publishers>
+            <LLHLS>
+                <Port>3333</Port>
+                <TLSPort>3334</TLSPort>
+                <WorkerCount>1</WorkerCount>
+            </LLHLS>
+        </Publishers>
+    </Bind>
+
+    <Defaults>
+        <CrossDomains>
+            <Url>*</Url>
+        </CrossDomains>
+    </Defaults>
+
+    <VirtualHosts>
+        <VirtualHost>
+            <Name>default</Name>
+            <Host>
+                <Names>
+                    <Name>*</Name>
+                </Names>
+            </Host>
+
+            <Applications>
+                <Application>
+                    <Name>app</Name>
+                    <Type>live</Type>
+
+                    <OutputProfiles>
+                        <OutputProfile>
+                            <Name>bypass_stream</Name>
+                            <OutputStreamName>${OriginStreamName}</OutputStreamName>
+                            <Playlist>
+                                <Name>default</Name>
+                                <FileName>master</FileName>
+                                <Options>
+                                    <EnableTsPackaging>true</EnableTsPackaging>
+                                </Options>
+                            </Playlist>
+                            <Encodes>
+                                <Video>
+                                    <Name>bypass_video</Name>
+                                    <Bypass>true</Bypass>
+                                </Video>
+                                <Audio>
+                                    <Name>bypass_audio</Name>
+                                    <Bypass>true</Bypass>
+                                </Audio>
+                            </Encodes>
+                        </OutputProfile>
+                    </OutputProfiles>
+
+                    <Providers>
+                        <RTMP />
+                        <SRT />
+                        <WebRTC />
+                    </Providers>
+
+                    <Publishers>
+                        <WebRTC>
+                            <CreateDefaultPlaylist>true</CreateDefaultPlaylist>
+                        </WebRTC>
+                        <LLHLS>
+                            <ChunkDuration>0.5</ChunkDuration>
+                            <SegmentDuration>6</SegmentDuration>
+                            <SegmentCount>10</SegmentCount>
+                            <CreateDefaultPlaylist>true</CreateDefaultPlaylist>
+                        </LLHLS>
+                        <HLS>
+                            <SegmentDuration>4</SegmentDuration>
+                            <SegmentCount>4</SegmentCount>
+                            <CreateDefaultPlaylist>true</CreateDefaultPlaylist>
+                        </HLS>
+                    </Publishers>
+                </Application>
+            </Applications>
+        </VirtualHost>
+    </VirtualHosts>
+</Server>

--- a/scripts/print_urls.ps1
+++ b/scripts/print_urls.ps1
@@ -1,0 +1,37 @@
+function Get-LanIp {
+    try {
+        $ips = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction Stop |
+            Where-Object { $_.IPAddress -notmatch '^127\.' -and $_.IPAddress -notmatch '^169\.254\.' } |
+            Select-Object -ExpandProperty IPAddress
+        if ($ips -and $ips.Count -gt 0) {
+            return $ips[0]
+        }
+    } catch {
+        # Ignore and try fallback
+    }
+
+    try {
+        $ips = Get-CimInstance Win32_NetworkAdapterConfiguration -Filter "IPEnabled = TRUE" |
+            ForEach-Object { $_.IPAddress } |
+            Where-Object { $_ -and $_ -notmatch ':' -and $_ -notmatch '^127\.' -and $_ -notmatch '^169\.254\.' }
+        if ($ips -and $ips.Count -gt 0) {
+            return $ips[0]
+        }
+    } catch {
+        # Ignore and return loopback
+    }
+
+    return "127.0.0.1"
+}
+
+$HostIp = Get-LanIp
+
+Write-Output "Detected LAN IP: $HostIp"
+Write-Output ""
+Write-Output "OBS RTMP Server: rtmp://$HostIp:1935/app"
+Write-Output "OBS Stream Key: stream"
+Write-Output "VLC (LL-HLS):   http://$HostIp:3333/app/stream/llhls.m3u8"
+Write-Output "VLC (HLS-TS):   http://$HostIp:3333/app/stream/master.m3u8?format=ts"
+Write-Output ""
+Write-Output "docker compose up -d"
+Write-Output "docker compose logs -f ovenmediaengine"

--- a/scripts/print_urls.sh
+++ b/scripts/print_urls.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+get_lan_ip() {
+  local ip
+  if command -v ip >/dev/null 2>&1; then
+    ip=$(ip -4 addr show scope global | awk '/inet / {print $2}' | cut -d/ -f1 | head -n1)
+    if [[ -n "${ip}" ]]; then
+      echo "${ip}"
+      return
+    fi
+  fi
+  if command -v hostname >/dev/null 2>&1; then
+    ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    if [[ -n "${ip}" ]]; then
+      echo "${ip}"
+      return
+    fi
+  fi
+  ip=$(getent hosts $(hostname) 2>/dev/null | awk '{print $1}' | head -n1)
+  if [[ -n "${ip}" ]]; then
+    echo "${ip}"
+    return
+  fi
+  echo "127.0.0.1"
+}
+
+HOST_IP=$(get_lan_ip)
+
+cat <<MSG
+Detected LAN IP: ${HOST_IP}
+
+OBS RTMP Server: rtmp://${HOST_IP}:1935/app
+OBS Stream Key: stream
+VLC (LL-HLS):   http://${HOST_IP}:3333/app/stream/llhls.m3u8
+VLC (HLS-TS):   http://${HOST_IP}:3333/app/stream/master.m3u8?format=ts
+
+docker compose up -d
+docker compose logs -f ovenmediaengine
+MSG


### PR DESCRIPTION
## Summary
- add a docker-compose service for OvenMediaEngine with the LAN ports and config volume needed for RTMP and LL-HLS ingest
- provide a trimmed OvenMediaEngine Server.xml enabling the app RTMP input along with LL-HLS and classic HLS outputs
- include helper scripts to print local testing URLs and document the OBS/VLC workflow in the README

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dabc712910832baf14595d56566259