### PR TITLE
Relax Python runtime enforcement

### DIFF
--- a/scripts/python_runtime.py
+++ b/scripts/python_runtime.py
@@ -1,0 +1,124 @@
+"""Shared helpers for ensuring the correct Python runtime is used."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VENV_DIR = REPO_ROOT / ".venv"
+REQUIRED_PYTHON: Tuple[int, int] = (3, 12)
+ENV_OVERRIDE = "WIFI_SILENT_DISCO_PYTHON"
+
+
+def venv_python_path() -> Path:
+    """Return the expected path to the project virtual environment Python."""
+    if os.name == "nt":
+        return VENV_DIR / "Scripts" / "python.exe"
+    return VENV_DIR / "bin" / "python"
+
+
+def _candidate_commands() -> Iterable[List[str]]:
+    required_major, required_minor = REQUIRED_PYTHON
+    candidates: List[List[str]] = []
+
+    override = os.environ.get(ENV_OVERRIDE)
+    if override:
+        candidates.append([override])
+
+    venv_python = venv_python_path()
+    if venv_python.exists():
+        candidates.append([str(venv_python)])
+
+    version_specific = [
+        f"python{required_major}.{required_minor}",
+        f"python{required_major}{required_minor}",
+        f"python{required_major}",
+        "python3",
+        "python",
+    ]
+    for name in version_specific:
+        path = shutil.which(name)
+        if path:
+            candidates.append([path])
+
+    if os.name == "nt":
+        launcher = shutil.which("py")
+        if launcher:
+            candidates.append([launcher, f"-{required_major}.{required_minor}"])
+
+    seen: set[Tuple[str, ...]] = set()
+    for command in candidates:
+        key = tuple(command)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield command
+
+
+def _probe_python_version(command: Sequence[str]) -> Tuple[int, int, int] | None:
+    try:
+        completed = subprocess.run(
+            [*command, "-c", "import json, sys; print(json.dumps(sys.version_info[:3]))"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    output = (completed.stdout or "").strip().splitlines()
+    if not output:
+        return None
+    try:
+        major, minor, micro = json.loads(output[-1])
+    except json.JSONDecodeError:
+        return None
+    return int(major), int(minor), int(micro)
+
+
+def _command_matches_current(command: Sequence[str]) -> bool:
+    if not command:
+        return False
+    if len(command) == 1:
+        try:
+            return Path(command[0]).resolve() == Path(sys.executable).resolve()
+        except FileNotFoundError:
+            return False
+    return False
+
+
+def ensure_required_python() -> None:
+    """Ensure the script is running under the required Python version.
+
+    If a matching interpreter is available but not currently being used the
+    process is re-executed using that interpreter.
+    """
+
+    current_major, current_minor = sys.version_info[:2]
+    if (current_major, current_minor) == REQUIRED_PYTHON:
+        return
+
+    required_major, required_minor = REQUIRED_PYTHON
+    for command in _candidate_commands():
+        version = _probe_python_version(command)
+        if version and version[:2] == REQUIRED_PYTHON:
+            if _command_matches_current(command):
+                return
+            display = " ".join(command)
+            print(
+                "Detected Python",
+                f"{current_major}.{current_minor}. Restarting with required interpreter '{display}'...",
+            )
+            os.execvpe(command[0], [*command, *sys.argv], os.environ)
+
+    raise SystemExit(
+        "WiFi Silent Disco tooling requires Python "
+        f"{required_major}.{required_minor}. Install it or set the {ENV_OVERRIDE} "
+        "environment variable to point at a compatible interpreter."
+    )

--- a/scripts/setup_ome_server.py
+++ b/scripts/setup_ome_server.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import shlex
 import shutil
 import socket
@@ -14,14 +13,21 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from python_runtime import (
+    REPO_ROOT,
+    REQUIRED_PYTHON,
+    VENV_DIR,
+    ensure_required_python,
+    venv_python_path,
+)
+
+ensure_required_python()
+
 ENV_PATH = REPO_ROOT / ".env"
 ENV_TEMPLATE_PATH = REPO_ROOT / ".env.example"
 REQUIREMENTS_FILE = REPO_ROOT / "requirements.txt"
-VENV_DIR = REPO_ROOT / ".venv"
 
-EXPECTED_MAJOR = 3
-EXPECTED_MINOR = 12
+EXPECTED_MAJOR, EXPECTED_MINOR = REQUIRED_PYTHON
 
 REQUIRED_COMMANDS = {
     "docker": "Docker is required to run OvenMediaEngine. Install Docker Desktop (Windows/macOS) or Docker Engine (Linux) and rerun this script.",
@@ -155,12 +161,6 @@ def _read_pyvenv_cfg(path: Path) -> Dict[str, str]:
     return data
 
 
-def _venv_python() -> Path:
-    if os.name == "nt":
-        return VENV_DIR / "Scripts" / "python.exe"
-    return VENV_DIR / "bin" / "python"
-
-
 def ensure_virtualenv(report: SetupReport) -> Path | None:
     recreate = False
     if VENV_DIR.exists():
@@ -183,7 +183,7 @@ def ensure_virtualenv(report: SetupReport) -> Path | None:
             return None
     else:
         report.add_action("Python virtual environment already exists.")
-    python_exec = _venv_python()
+    python_exec = venv_python_path()
     if not python_exec.exists():
         report.add_error("Virtual environment python executable is missing. Try deleting the .venv folder and rerun the setup.")
         return None

--- a/scripts/start_stream_server.py
+++ b/scripts/start_stream_server.py
@@ -2,45 +2,14 @@
 """Interactive controller for the WiFi Silent Disco streaming stack."""
 from __future__ import annotations
 
-import os
-import sys
 from pathlib import Path
 
-EXPECTED_MAJOR = 3
-EXPECTED_MINOR = 12
+from python_runtime import ensure_required_python
+
+
+ensure_required_python()
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-VENV_DIR = REPO_ROOT / ".venv"
-
-
-def _venv_python_path() -> Path:
-    if os.name == "nt":
-        return VENV_DIR / "Scripts" / "python.exe"
-    return VENV_DIR / "bin" / "python"
-
-
-def ensure_python_runtime() -> None:
-    major, minor, micro = sys.version_info[:3]
-    if (major, minor) == (EXPECTED_MAJOR, EXPECTED_MINOR):
-        return
-
-    venv_python = _venv_python_path()
-    current_exec = Path(sys.executable).resolve()
-    if venv_python.exists() and current_exec != venv_python.resolve():
-        print(
-            "Detected Python"
-            f" {major}.{minor}.{micro}. Restarting with project interpreter {venv_python}..."
-        )
-        os.execv(str(venv_python), [str(venv_python), *sys.argv])
-
-    raise SystemExit(
-        "WiFi Silent Disco requires Python "
-        f"{EXPECTED_MAJOR}.{EXPECTED_MINOR}. Detected {major}.{minor}.{micro}. "
-        "Install the required version and rerun the script."
-    )
-
-
-ensure_python_runtime()
 
 import json
 import queue


### PR DESCRIPTION
## Summary
- add a shared python_runtime helper that locates the required interpreter, prefers the project virtualenv, and allows an override via WIFI_SILENT_DISCO_PYTHON
- update setup_ome_server to rely on the shared runtime helper so it re-executes itself with the correct Python and shares the virtualenv locator
- switch start_stream_server to use the shared runtime helper so the GUI controller automatically restarts under the expected interpreter

## Testing
- python3 -m compileall scripts
- python3 scripts/setup_ome_server.py --help

------
https://chatgpt.com/codex/tasks/task_e_68db1f266868832ba2d7f0e290e37809