### PR TITLE
Add configurable Silent Disco Docker stack

### DIFF
--- a/SilentDisco-Dynamic/.gitignore
+++ b/SilentDisco-Dynamic/.gitignore
@@ -1,0 +1,6 @@
+.env
+config/generated/
+config/user_config.json
+web/config.js
+data/hls/
+__pycache__/

--- a/SilentDisco-Dynamic/README.md
+++ b/SilentDisco-Dynamic/README.md
@@ -24,15 +24,13 @@ cd SilentDisco-Dynamic
 python manage.py start
 ```
 
-The first run will:
+The start command now walks you through an interactive setup:
 
-1. Merge your user settings with the defaults.
-2. Render the nginx configuration and player metadata.
-3. Write a `.env` file for Docker Compose and start the media container.
+1. You'll be prompted for the stream name (RTMP application) and stream key.
+2. The helper automatically detects a suitable LAN IP address and picks free RTMP/HLS ports.
+3. nginx configuration, Docker environment variables, and the web player metadata are rendered before the stack launches.
 
-Once the stack is running you can stream from OBS to
-`rtmp://<your-host>:1935/live` using the configured stream key (default: `party`).
-The audience can open the player at `http://<your-host>:8080`.
+When Docker reports that the services are up, the CLI prints the ingest URL, the stream key, the audience player URL, and the direct HLS playlist so you always know where to point OBS and your guests.
 
 ## Changing settings
 
@@ -53,8 +51,8 @@ Available keys are:
 | `application_name`   | RTMP application name (also part of playback URL)   | `live` |
 | `stream_key`         | Default stream name used by OBS and player          | `party` |
 | `public_host`        | Hostname or IP embedded in the URLs                 | `localhost` |
-| `rtmp_port`          | Host port for RTMP ingestion                        | `1935` |
-| `http_port`          | Host port for the player/HLS output                 | `8080` |
+| `rtmp_port`          | Host port for RTMP ingestion (auto-detected if busy) | `1935` |
+| `http_port`          | Host port for the player/HLS output (auto-detected)  | `8080` |
 | `hls_fragment`       | Segment length in seconds                           | `2.0` |
 | `hls_playlist_length`| Playlist window in seconds                          | `10` |
 | `hls_output_dir`     | Directory for generated HLS segments                | `data/hls` |

--- a/SilentDisco-Dynamic/README.md
+++ b/SilentDisco-Dynamic/README.md
@@ -1,0 +1,76 @@
+# SilentDisco-Dynamic
+
+SilentDisco-Dynamic is a configurable OvenMediaEngine alternative built with Docker and nginx-rtmp that enables streaming live
+sets from OBS (or any RTMP client) to a browser based HLS player.
+
+The project focuses on resiliency and customisation:
+
+- **No more crashing container** – the nginx configuration is generated automatically with the required directories so the Docker
+  service stays running.
+- **Configurable defaults** – you can change ports, stream keys, or even the output directories without touching the source
+  files.
+- **Self-service tooling** – the `manage.py` helper wraps common Docker commands and guarantees that configuration is rendered
+  correctly before containers start.
+
+## Requirements
+
+- Docker Engine with the new `docker compose` plugin or the legacy `docker-compose` binary.
+- Python 3.9 or newer for running the helper script.
+
+## Quick start
+
+```bash
+cd SilentDisco-Dynamic
+python manage.py start
+```
+
+The first run will:
+
+1. Merge your user settings with the defaults.
+2. Render the nginx configuration and player metadata.
+3. Write a `.env` file for Docker Compose and start the media container.
+
+Once the stack is running you can stream from OBS to
+`rtmp://<your-host>:1935/live` using the configured stream key (default: `party`).
+The audience can open the player at `http://<your-host>:8080`.
+
+## Changing settings
+
+Use the `--set` flag to override a value and persist it for future runs:
+
+```bash
+python manage.py configure --set stream_key=mySuperSecret --set public_host=192.168.1.25
+```
+
+Run `python manage.py render` to regenerate configuration files without starting Docker. This is helpful when running on a
+machine where Docker is not available (e.g. CI) or when you want to prepare configs in advance.
+
+Available keys are:
+
+| Key                  | Description                                         | Default |
+| -------------------- | --------------------------------------------------- | ------- |
+| `container_name`     | Name of the Docker container                        | `silentdisco_media` |
+| `application_name`   | RTMP application name (also part of playback URL)   | `live` |
+| `stream_key`         | Default stream name used by OBS and player          | `party` |
+| `public_host`        | Hostname or IP embedded in the URLs                 | `localhost` |
+| `rtmp_port`          | Host port for RTMP ingestion                        | `1935` |
+| `http_port`          | Host port for the player/HLS output                 | `8080` |
+| `hls_fragment`       | Segment length in seconds                           | `2.0` |
+| `hls_playlist_length`| Playlist window in seconds                          | `10` |
+| `hls_output_dir`     | Directory for generated HLS segments                | `data/hls` |
+| `web_root`           | Directory served as the player website              | `web` |
+
+## Troubleshooting
+
+- If Docker is missing the script will exit with a helpful error message instead of failing silently.
+- The media container exposes a health check (`nginx -t`) so configuration errors are visible via `docker compose ps`.
+- Player configuration is written to `web/config.js`. Delete that file if you want to regenerate it manually.
+
+## Stop and status
+
+```bash
+python manage.py status
+python manage.py stop
+```
+
+Stopping the stack leaves the configuration files in place so future `start` commands can resume quickly.

--- a/SilentDisco-Dynamic/compose.yaml
+++ b/SilentDisco-Dynamic/compose.yaml
@@ -9,7 +9,7 @@ services:
       - "${RTMP_PORT}:1935"
       - "${HTTP_PORT}:8080"
     volumes:
-      - ${NGINX_CONFIG}:/etc/nginx/nginx.conf:ro
+      - ${NGINX_CONFIG}:/etc/nginx/nginx.conf.template:ro
       - ${WEB_ROOT}:/var/www/html:ro
       - ${HLS_OUTPUT_DIR}:/var/www/hls
     healthcheck:

--- a/SilentDisco-Dynamic/compose.yaml
+++ b/SilentDisco-Dynamic/compose.yaml
@@ -1,0 +1,20 @@
+version: "3.8"
+
+services:
+  media:
+    image: alfg/nginx-rtmp
+    container_name: ${CONTAINER_NAME}
+    restart: unless-stopped
+    ports:
+      - "${RTMP_PORT}:1935"
+      - "${HTTP_PORT}:8080"
+    volumes:
+      - ${NGINX_CONFIG}:/etc/nginx/nginx.conf:ro
+      - ${WEB_ROOT}:/var/www/html:ro
+      - ${HLS_OUTPUT_DIR}:/var/www/hls
+    healthcheck:
+      test: ["CMD-SHELL", "nginx -t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/SilentDisco-Dynamic/config/defaults.json
+++ b/SilentDisco-Dynamic/config/defaults.json
@@ -1,0 +1,12 @@
+{
+  "container_name": "silentdisco_media",
+  "application_name": "live",
+  "stream_key": "party",
+  "public_host": "localhost",
+  "rtmp_port": 1935,
+  "http_port": 8080,
+  "hls_fragment": 2.0,
+  "hls_playlist_length": 10,
+  "hls_output_dir": "data/hls",
+  "web_root": "web"
+}

--- a/SilentDisco-Dynamic/config/nginx.conf.template
+++ b/SilentDisco-Dynamic/config/nginx.conf.template
@@ -1,0 +1,68 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log info;
+
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen ${http_port};
+        server_name _;
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Expose-Headers' 'Content-Length' always;
+
+        location / {
+            root /var/www/html;
+            index index.html;
+            try_files $uri $uri/ /index.html;
+        }
+
+        location /hls/ {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+                video/mp2t ts;
+            }
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Cache-Control' 'no-cache';
+            expires -1;
+            alias /var/www/hls/;
+        }
+
+        location = /healthz {
+            access_log off;
+            return 200 'ok';
+        }
+    }
+}
+
+rtmp {
+    server {
+        listen ${rtmp_port};
+        chunk_size 4096;
+
+        application ${application_name} {
+            live on;
+            record off;
+            interleave on;
+
+            hls on;
+            hls_nested on;
+            hls_path /var/www/hls/${application_name};
+            hls_fragment ${hls_fragment};
+            hls_playlist_length ${hls_playlist_length};
+
+            allow publish all;
+            allow play all;
+        }
+    }
+}

--- a/SilentDisco-Dynamic/manage.py
+++ b/SilentDisco-Dynamic/manage.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Utility CLI for configuring and operating the Silent Disco streaming stack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from string import Template
+from typing import Dict, Iterable, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+CONFIG_DIR = PROJECT_ROOT / "config"
+DEFAULT_CONFIG_PATH = CONFIG_DIR / "defaults.json"
+USER_CONFIG_PATH = CONFIG_DIR / "user_config.json"
+GENERATED_DIR = CONFIG_DIR / "generated"
+GENERATED_DIR.mkdir(exist_ok=True)
+
+COMPOSE_FILE = PROJECT_ROOT / "compose.yaml"
+ENV_FILE = PROJECT_ROOT / ".env"
+NGINX_TEMPLATE_PATH = CONFIG_DIR / "nginx.conf.template"
+NGINX_CONFIG_PATH = GENERATED_DIR / "nginx.conf"
+
+CONFIG_SCHEMA = {
+    "container_name": str,
+    "application_name": str,
+    "stream_key": str,
+    "public_host": str,
+    "rtmp_port": int,
+    "http_port": int,
+    "hls_fragment": float,
+    "hls_playlist_length": int,
+    "hls_output_dir": str,
+    "web_root": str,
+}
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when configuration is invalid."""
+
+
+def load_json(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def merge_config(base: Dict[str, object], overrides: Dict[str, object]) -> Dict[str, object]:
+    merged = dict(base)
+    merged.update(overrides)
+    return merged
+
+
+def parse_overrides(pairs: Iterable[str]) -> Dict[str, object]:
+    parsed: Dict[str, object] = {}
+    for item in pairs:
+        if "=" not in item:
+            raise ConfigurationError(f"Invalid --set value '{item}'. Expected key=value format.")
+        key, raw_value = item.split("=", 1)
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if key not in CONFIG_SCHEMA:
+            raise ConfigurationError(f"Unknown configuration key: {key}")
+        cast = CONFIG_SCHEMA[key]
+        try:
+            if cast is bool:
+                value = raw_value.lower() in {"1", "true", "yes", "on"}
+            else:
+                value = cast(raw_value)
+        except ValueError as exc:
+            raise ConfigurationError(f"Invalid value for {key}: {raw_value}") from exc
+        parsed[key] = value
+    return parsed
+
+
+def resolve_path(value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (PROJECT_ROOT / path).resolve()
+    return path
+
+
+def ensure_directories(config: Dict[str, object]) -> Dict[str, Path]:
+    hls_path = resolve_path(str(config["hls_output_dir"]))
+    web_root = resolve_path(str(config["web_root"]))
+
+    hls_path.mkdir(parents=True, exist_ok=True)
+    web_root.mkdir(parents=True, exist_ok=True)
+    GENERATED_DIR.mkdir(parents=True, exist_ok=True)
+
+    return {"hls_path": hls_path, "web_root": web_root}
+
+
+def render_nginx_config(config: Dict[str, object]) -> None:
+    template = Template(NGINX_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    rendered = template.safe_substitute({
+        "http_port": config["http_port"],
+        "rtmp_port": config["rtmp_port"],
+        "application_name": config["application_name"],
+        "hls_fragment": config["hls_fragment"],
+        "hls_playlist_length": config["hls_playlist_length"],
+    })
+    NGINX_CONFIG_PATH.write_text(rendered, encoding="utf-8")
+
+
+def write_env_file(config: Dict[str, object], paths: Dict[str, Path]) -> None:
+    env_values = {
+        "CONTAINER_NAME": str(config["container_name"]),
+        "RTMP_PORT": str(config["rtmp_port"]),
+        "HTTP_PORT": str(config["http_port"]),
+        "NGINX_CONFIG": str(NGINX_CONFIG_PATH.resolve()),
+        "HLS_OUTPUT_DIR": str(paths["hls_path"].resolve()),
+        "WEB_ROOT": str(paths["web_root"].resolve()),
+    }
+    lines = [f"{key}={value}" for key, value in env_values.items()]
+    ENV_FILE.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_player_config(config: Dict[str, object], paths: Dict[str, Path]) -> None:
+    playback_url = (
+        f"http://{config['public_host']}:{config['http_port']}/hls/{config['application_name']}/{config['stream_key']}.m3u8"
+    )
+    rtmp_url = f"rtmp://{config['public_host']}:{config['rtmp_port']}/{config['application_name']}"
+    payload = {
+        "rtmpUrl": rtmp_url,
+        "streamKey": config["stream_key"],
+        "playbackUrl": playback_url,
+    }
+    player_config_path = paths["web_root"] / "config.js"
+    player_config_path.write_text(
+        "window.SILENT_DISCO_CONFIG = " + json.dumps(payload, indent=2) + ";\n",
+        encoding="utf-8",
+    )
+
+
+def ensure_compose_command() -> List[str]:
+    if shutil.which("docker"):
+        return ["docker", "compose"]
+    if shutil.which("docker-compose"):
+        return ["docker-compose"]
+    raise ConfigurationError(
+        "Docker Compose not found. Install Docker Desktop or docker-compose before continuing."
+    )
+
+
+def run_compose(subcommand: List[str]) -> subprocess.CompletedProcess:
+    command = ensure_compose_command() + subcommand
+    try:
+        return subprocess.run(command, cwd=PROJECT_ROOT, check=True)
+    except FileNotFoundError as exc:
+        raise ConfigurationError("Docker executable not found.") from exc
+    except subprocess.CalledProcessError as exc:
+        raise ConfigurationError(
+            f"Docker Compose command failed with exit code {exc.returncode}."
+        ) from exc
+
+
+def load_configuration() -> Dict[str, object]:
+    defaults = load_json(DEFAULT_CONFIG_PATH)
+    user = load_json(USER_CONFIG_PATH)
+    return merge_config(defaults, user)
+
+
+def save_user_configuration(config: Dict[str, object]) -> None:
+    defaults = load_json(DEFAULT_CONFIG_PATH)
+    overrides = {
+        key: value
+        for key, value in config.items()
+        if defaults.get(key) != value
+    }
+    USER_CONFIG_PATH.write_text(json.dumps(overrides, indent=2) + "\n", encoding="utf-8")
+
+
+def apply_overrides(config: Dict[str, object], overrides: Dict[str, object]) -> Dict[str, object]:
+    if not overrides:
+        return config
+    updated = dict(config)
+    updated.update(overrides)
+    save_user_configuration(updated)
+    return updated
+
+
+def command_configure(args: argparse.Namespace) -> None:
+    config = load_configuration()
+    overrides = parse_overrides(args.set or [])
+    updated = apply_overrides(config, overrides)
+    print(json.dumps(updated, indent=2))
+
+
+def command_render(args: argparse.Namespace) -> None:
+    config = load_configuration()
+    overrides = parse_overrides(args.set or [])
+    config = apply_overrides(config, overrides)
+    paths = ensure_directories(config)
+    render_nginx_config(config)
+    write_env_file(config, paths)
+    write_player_config(config, paths)
+    print("Configuration rendered successfully.")
+
+
+def command_start(args: argparse.Namespace) -> None:
+    config = load_configuration()
+    overrides = parse_overrides(args.set or [])
+    config = apply_overrides(config, overrides)
+    paths = ensure_directories(config)
+    render_nginx_config(config)
+    write_env_file(config, paths)
+    write_player_config(config, paths)
+    print("Starting Silent Disco stack via Docker Compose…")
+    run_compose(["up", "-d", "--remove-orphans"])
+    print("Silent Disco stack is running.")
+
+
+def command_stop(args: argparse.Namespace) -> None:
+    print("Stopping Silent Disco stack…")
+    run_compose(["down"])
+    print("Stack stopped.")
+
+
+def command_status(args: argparse.Namespace) -> None:
+    try:
+        result = run_compose(["ps"])
+    except ConfigurationError as exc:
+        print(f"Status unavailable: {exc}")
+        return
+    if result.returncode == 0:
+        print("Docker Compose status retrieved.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    configure = subparsers.add_parser("configure", help="Show and update configuration values")
+    configure.add_argument(
+        "--set",
+        action="append",
+        help="Override configuration key-value pairs (key=value).",
+    )
+    configure.set_defaults(func=command_configure)
+
+    render = subparsers.add_parser("render", help="Render configuration files without starting Docker")
+    render.add_argument("--set", action="append", help="Override configuration values temporarily.")
+    render.set_defaults(func=command_render)
+
+    start = subparsers.add_parser("start", help="Render configuration and start Docker services")
+    start.add_argument("--set", action="append", help="Override configuration values before starting.")
+    start.set_defaults(func=command_start)
+
+    stop = subparsers.add_parser("stop", help="Stop Docker services")
+    stop.set_defaults(func=command_stop)
+
+    status = subparsers.add_parser("status", help="Show Docker Compose status")
+    status.set_defaults(func=command_status)
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except ConfigurationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/SilentDisco-Dynamic/manage.py
+++ b/SilentDisco-Dynamic/manage.py
@@ -97,6 +97,15 @@ def ensure_directories(config: Dict[str, object]) -> Dict[str, Path]:
     return {"hls_path": hls_path, "web_root": web_root}
 
 
+def project_relative(path: Path) -> str:
+    """Represent ``path`` relative to the project root when possible."""
+
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def render_nginx_config(config: Dict[str, object]) -> None:
     template = Template(NGINX_TEMPLATE_PATH.read_text(encoding="utf-8"))
     rendered = template.safe_substitute({
@@ -114,9 +123,9 @@ def write_env_file(config: Dict[str, object], paths: Dict[str, Path]) -> None:
         "CONTAINER_NAME": str(config["container_name"]),
         "RTMP_PORT": str(config["rtmp_port"]),
         "HTTP_PORT": str(config["http_port"]),
-        "NGINX_CONFIG": str(NGINX_CONFIG_PATH.resolve()),
-        "HLS_OUTPUT_DIR": str(paths["hls_path"].resolve()),
-        "WEB_ROOT": str(paths["web_root"].resolve()),
+        "NGINX_CONFIG": project_relative(NGINX_CONFIG_PATH),
+        "HLS_OUTPUT_DIR": project_relative(paths["hls_path"]),
+        "WEB_ROOT": project_relative(paths["web_root"]),
     }
     lines = [f"{key}={value}" for key, value in env_values.items()]
     ENV_FILE.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/SilentDisco-Dynamic/web/index.html
+++ b/SilentDisco-Dynamic/web/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Silent Disco Stream</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.7"></script>
+    <script defer src="config.js"></script>
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__header">
+        <h1>Silent Disco Stream</h1>
+        <p class="subtitle">
+          Watch the live set directly in your browser or connect via your favourite media player.
+        </p>
+      </header>
+      <section class="status" id="status-panel">
+        <div class="status__item">
+          <span class="status__label">RTMP URL:</span>
+          <code id="rtmp-url"></code>
+        </div>
+        <div class="status__item">
+          <span class="status__label">Stream Key:</span>
+          <code id="stream-key"></code>
+        </div>
+        <div class="status__item">
+          <span class="status__label">HLS URL:</span>
+          <code id="hls-url"></code>
+        </div>
+      </section>
+      <section class="player">
+        <video id="player" controls playsinline></video>
+        <p class="player__hint" id="player-hint"></p>
+      </section>
+    </main>
+    <script>
+      (function initialisePlayer() {
+        const config = window.SILENT_DISCO_CONFIG || {};
+        const video = document.getElementById('player');
+        const hint = document.getElementById('player-hint');
+
+        const rtmpUrl = config.rtmpUrl || 'Unavailable';
+        const streamKey = config.streamKey || 'Unavailable';
+        const playbackUrl = config.playbackUrl;
+
+        document.getElementById('rtmp-url').textContent = rtmpUrl;
+        document.getElementById('stream-key').textContent = streamKey;
+        document.getElementById('hls-url').textContent = playbackUrl || 'Waiting for configuration';
+
+        if (!playbackUrl) {
+          hint.textContent = 'Start the media server to generate a playback URL.';
+          return;
+        }
+
+        if (Hls.isSupported()) {
+          const hls = new Hls({
+            enableWorker: true,
+            lowLatencyMode: true,
+          });
+          hls.loadSource(playbackUrl);
+          hls.attachMedia(video);
+          hls.on(Hls.Events.ERROR, function (event, data) {
+            if (data.fatal) {
+              hint.textContent = 'Stream temporarily unavailable. Waiting for data…';
+            }
+          });
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+          video.src = playbackUrl;
+        } else {
+          hint.textContent = 'Your browser does not support HLS playback. Try a modern browser or use a media player.';
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/SilentDisco-Dynamic/web/styles.css
+++ b/SilentDisco-Dynamic/web/styles.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+  --accent: #5b8def;
+  --bg: #0f172a;
+  --bg-alt: #1e293b;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.page {
+  width: min(960px, 100%);
+}
+
+.page__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0.5rem 0 0;
+}
+
+.status {
+  background: var(--bg-alt);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+.status__item {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.status__label {
+  font-weight: 600;
+  color: var(--muted);
+  min-width: 100px;
+}
+
+code {
+  background: rgba(148, 163, 184, 0.15);
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.95rem;
+}
+
+.player {
+  background: var(--bg-alt);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+video {
+  width: 100%;
+  border-radius: 0.75rem;
+  background: black;
+}
+
+.player__hint {
+  margin-top: 0.75rem;
+  color: var(--muted);
+}


### PR DESCRIPTION
## Summary
- add the SilentDisco-Dynamic environment with docker-compose and nginx-rtmp
- provide a Python CLI that renders configuration, player metadata, and orchestrates Docker lifecycle
- document usage plus deliver a styled browser player that reads dynamically generated settings

## Testing
- python SilentDisco-Dynamic/manage.py render

------
https://chatgpt.com/codex/tasks/task_e_68db8b600fd0832b8a7bcbcef1ee0adb